### PR TITLE
disable acl for public access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,4 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync with S3
-        run: aws s3 sync ./website s3://${{ env.S3_BUCKET }} --delete --acl public-read
+        run: aws s3 sync ./website s3://${{ env.S3_BUCKET }} --delete


### PR DESCRIPTION
Now we use CloudFront as distribution service. A public S3 bucket is no longer required.